### PR TITLE
support base fields other than 𝔽ₚ[√-1]

### DIFF
--- a/Theta-SageMath/theta_isogenies/isomorphism.py
+++ b/Theta-SageMath/theta_isogenies/isomorphism.py
@@ -88,9 +88,13 @@ class SplittingIsomorphism(Isomorphism):
             raise ValueError("Domain must be a Theta Structure")
         self._domain = domain
 
-        # We need a second root of unity
+        # We need a fourth root of unity
         if zeta is None:
-            self.zeta = domain.base_ring().gen()
+            F = domain.base_ring()
+            if F.degree() == 2 and F.gen()**2 == -1:
+                self.zeta = F.gen()
+            else:
+                self.zeta = F(-1).sqrt(extend=False)
 
         # Select the precomputed change of basis to map the zero to (11, 11) by
         # identifying the current zero index.
@@ -157,7 +161,7 @@ class SplittingIsomorphism(Isomorphism):
         """
 
         null_coords = self.domain().coords()
-        i = self.zeta  # self.domain().base_ring().gen()
+        i = self.zeta
         assert i**2 == -1
 
         # Computed from description in the paper.

--- a/Theta-SageMath/utilities/fast_sqrt.py
+++ b/Theta-SageMath/utilities/fast_sqrt.py
@@ -49,6 +49,13 @@ def sqrt_Fp2(x, canonical=False):
     Fast computation of square-roots in SageMath using that p = 3 mod 4
     """
     F = x.parent()
+
+    if F.degree() != 2 or F.gen()**2 != -1:
+        # base field is not 𝔽ₚ[√-1]: fall back to built-in .sqrt() method
+        if canonical:
+            return min(x.sqrt(extend=False, all=True))
+        return x.sqrt(extend=False)
+
     x0, x1 = x.list()
 
     if x1 == 0:


### PR DESCRIPTION
Currently the code silently assumes that $p\equiv3\pmod4$ and that the base field is $\mathbb F_p[\sqrt{-1}]$. With these two simple changes everything seems to work for general base fields (albeit with significantly slower square roots, of course).