### PR TITLE
do not override user-chosen recursion limit unless necessary

### DIFF
--- a/Theta-SageMath/utilities/strategy.py
+++ b/Theta-SageMath/utilities/strategy.py
@@ -33,8 +33,6 @@ def optimised_strategy_old(n, mul_c=1):
 import functools
 import sys
 
-sys.setrecursionlimit(1500)
-
 # fmt: off
 def optimised_strategy(n):
     """
@@ -114,6 +112,9 @@ def optimised_strategy(n):
                 doubles.append(d)
                 kernels.append(point - d)
         return doubles
+
+    if sys.getrecursionlimit() < 1000 + n:
+        sys.setrecursionlimit(1000 + n)
 
     # Compute the cost and populate the checkpoints
     c = cost(n, True)


### PR DESCRIPTION
For large computations, the default stack depth limit of 1500 set by the library may be too small. With this simple change we (1) make sure to never *de*crease the existing limit, and (2) set the limit depending on the expected recursion depth (`n`) instead of blindly using a somewhat arbitrary value.